### PR TITLE
Multiplayer Fixes

### DIFF
--- a/SRPlaylistManager/Harmony/Patch_MultiplayerFavoritesController_OnPointerDown.cs
+++ b/SRPlaylistManager/Harmony/Patch_MultiplayerFavoritesController_OnPointerDown.cs
@@ -18,7 +18,7 @@ namespace SRPlaylistManager.Harmony
             __instance.tooltip = "Select Playlists";
 
             // Treat the click as the end to the hover, to hide the tooltip
-            //__instance.OnPointerExit(eventData);
+            __instance.OnPointerExit(eventData);
             __instance.isHovered = false;
 
             SRPlaylistManager.Instance?.OnToggleMultiplayerPlaylistButton();

--- a/SRPlaylistManager/Harmony/Patch_MultiplayerRoomView_FillSelectedTrackData.cs
+++ b/SRPlaylistManager/Harmony/Patch_MultiplayerRoomView_FillSelectedTrackData.cs
@@ -11,7 +11,6 @@ namespace SRPlaylistManager.Harmony
         public static void Postfix()
         {
             // Make sure the playlist button is properly set up!
-            SRPlaylistManager.Instance.LogVerbose("FillSelectedTrackData");
             SRPlaylistManager.Instance.OnMultiplayerTrackFill();
         }
     }

--- a/SRPlaylistManager/Harmony/Patch_MultiplayerRoomView_FillSelectedTrackData.cs
+++ b/SRPlaylistManager/Harmony/Patch_MultiplayerRoomView_FillSelectedTrackData.cs
@@ -1,0 +1,18 @@
+﻿using HarmonyLib;
+using Il2CppSynth.Multiplayer;
+
+namespace SRPlaylistManager.Harmony
+{
+    // This is called during initialization (for the host),
+    // and from Game_InfoProvider.OnEvent() with event code SetSelectedVersusTrack (for clients)
+    [HarmonyPatch(typeof(MultiplayerRoomView), nameof(MultiplayerRoomView.FillSelectedTrackData))]
+    public class Patch_MultiplayerRoomView_FillSelectedTrackData
+    {
+        public static void Postfix()
+        {
+            // Make sure the playlist button is properly set up!
+            SRPlaylistManager.Instance.LogVerbose("FillSelectedTrackData");
+            SRPlaylistManager.Instance.OnMultiplayerTrackFill();
+        }
+    }
+}

--- a/SRPlaylistManager/Harmony/Patch_PlaylistManagementController_TryDisplayCorrectRemoveFavoriteButton.cs
+++ b/SRPlaylistManager/Harmony/Patch_PlaylistManagementController_TryDisplayCorrectRemoveFavoriteButton.cs
@@ -16,22 +16,6 @@ namespace SRPlaylistManager.Harmony
         {
             SetupToggleButton(__instance.pf_RemoveFromPlaylistButton);
             SetupToggleButton(__instance.pf_SongAddFavoriteButton);
-
-            // TODO figure out how to do the heart visible or not based on if in _any_ playlist
-
-            //// Override the remove button text
-            //var btnText = __instance.pf_RemoveFromPlaylistButton?.GetComponentInChildren<TMP_Text>(true);
-            //SRPlaylistManager.Instance.Log("Remove favorite btn text: " + btnText);
-            //btnText?.SetText("Playlist", true);
-
-            //// Also add in our own behavior
-            //var button = __instance.pf_RemoveFromPlaylistButton?.GetComponentInChildren<SynthUIButton>();
-            //SRPlaylistManager.Instance.Log("Remove favorite btn: " + button);
-            //button.WhenClicked = new UnityEngine.Events.UnityEvent();
-            //button.WhenClicked.AddListener(new Action(() => { SRPlaylistManager.Instance.OnToggleMainMenuPlaylistButton(); }));
-
-            // Hide icon. Still off-center, but not as obviously a different button :)
-            //__instance.pf_SongAddFavoriteButton?.transform.Find("Icon")?.gameObject.SetActive(false);
         }
 
         private static void SetupToggleButton(GameObject buttonGO)
@@ -49,6 +33,7 @@ namespace SRPlaylistManager.Harmony
             // Make sure the tooltip doesn't linger when we open up the playlist selection
             var button = buttonGO.GetComponentInChildren<SynthUIButton>();
             button.hideTooltipOnClick = true;
+            button.stayHoveredwhenClicked = false;
 
             // Also add in our own behavior
             if (button != null)

--- a/SRPlaylistManager/Harmony/Patch_SongSelectionManager_OpenMultiplayerRoomMenu.cs
+++ b/SRPlaylistManager/Harmony/Patch_SongSelectionManager_OpenMultiplayerRoomMenu.cs
@@ -1,0 +1,19 @@
+﻿using Il2CppSynth.SongSelection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+
+namespace SRPlaylistManager.Harmony
+{
+    [HarmonyPatch(typeof(SongSelectionManager), nameof(SongSelectionManager.OpenMultiplayerRoomMenu))]
+    public class Patch_SongSelectionManager_OpenMultiplayerRoomMenu
+    {
+        public static void Postfix(Il2CppSynth.Versus.Room room)
+        {
+            SRPlaylistManager.Instance?.OnOpenMultiplayerRoomMenu(room);
+        }
+    }
+}

--- a/SRPlaylistManager/Harmony/Patch_SongSelectionManager_ToggleFavorite.cs
+++ b/SRPlaylistManager/Harmony/Patch_SongSelectionManager_ToggleFavorite.cs
@@ -6,9 +6,11 @@ namespace SRPlaylistManager.Harmony
     [HarmonyPatch(typeof(SongSelectionManager), nameof(SongSelectionManager.ToggleFavorite))]
     public class Patch_SongSelectionManager_ToggleFavorite
     {
-        public static bool Prefix()
+        public static bool Prefix(SongSelectionManager __instance)
         {
             SRPlaylistManager.Instance?.OnToggleMainMenuPlaylistButton();
+
+            __instance.UpdateFavoriteButtonState();
 
             // Don't follow the normal "Add/Remove Favorites" logic
             return false;

--- a/SRPlaylistManager/Harmony/Patch_SongSelectionManager_UpdateFavoriteButtonState.cs
+++ b/SRPlaylistManager/Harmony/Patch_SongSelectionManager_UpdateFavoriteButtonState.cs
@@ -1,24 +1,51 @@
 ﻿using HarmonyLib;
+using Il2Cpp;
 using Il2CppSynth.SongSelection;
 using SRModCore;
+using UnityEngine.Playables;
+using static MelonLoader.MelonLogger;
 
 namespace SRPlaylistManager.Harmony
 {
     [HarmonyPatch(typeof(SongSelectionManager), "UpdateFavoriteButtonState")]
     public class Patch_SongSelectionManager_UpdateFavoriteButtonState
     {
-        public static bool Prefix(SongSelectionManager __instance)
+        public static void Postfix(SongSelectionManager __instance)
+        {
+            SetupButton(__instance);
+        }
+
+        private static void SetupButton(SongSelectionManager __instance)
         {
             // Don't follow the normal text changes
             // TODO better text and do translation
-            __instance.favoriteBtn.toolTipLabelNormal = "Select Playlists";
-            __instance.favoriteBtn.toolTipLabelSelected = "Select Playlists";
+            if (__instance.favoriteBtn == null)
+            {
+                SRPlaylistManager.Instance.Log("favoriteBtn was null!");
+            }
+            else
+            {
+                __instance.favoriteBtn.toolTipLabelNormal = "Select Playlists";
+                __instance.favoriteBtn.toolTipLabelSelected = "Select Playlists";
 
-            __instance.favoriteBtn.synthUIButton.SetText("Select Playlists");
+                if (__instance.favoriteBtn.synthUIButton == null)
+                {
+                    SRPlaylistManager.Instance.Log("synthUIButton was null!");
+                }
+                else
+                {
+                    __instance.favoriteBtn.synthUIButton.SetText("Select Playlists");
+                    __instance.favoriteBtn.synthUIButton.stayHoveredwhenClicked = false;
+                    __instance.favoriteBtn.synthUIButton.hideTooltipOnClick = true;
+                }
 
-            // TODO set state based on if the current song is in _any_ playlist, not just favorites?
-
-            return true;
+                //// TODO If favorited, use the filled pink heart.
+                //// If not favorited but in a playlist, use the filled neutral heart.
+                //// If not in either, use the empty heart.
+                //SRPlaylistManager.Instance.GetCurrentSongPlaylistState(out var isInFavorites, out var isInPlaylist);
+                //var buttonIcon = __instance.favoriteBtn;
+                //var buttonAddFav = __instance.addToFavoriteButton;
+            }
         }
     }
 }

--- a/SRPlaylistManager/Harmony/Patch_SongSelectionManager_UpdateFavoriteButtonState.cs
+++ b/SRPlaylistManager/Harmony/Patch_SongSelectionManager_UpdateFavoriteButtonState.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using Il2Cpp;
+using Il2Cppcom.Kluge.XR.Utils;
 using Il2CppSynth.SongSelection;
 using SRModCore;
 using UnityEngine.Playables;

--- a/SRPlaylistManager/Models/PlaylistPanelItem.cs
+++ b/SRPlaylistManager/Models/PlaylistPanelItem.cs
@@ -11,6 +11,7 @@ using Il2CppUtil.Controller;
 using Il2CppUtil.Data;
 using System.Collections.Generic;
 using Il2CppSynth.Data;
+using UnityEngine.UI;
 
 namespace SRPlaylistManager.Models
 {
@@ -107,6 +108,9 @@ namespace SRPlaylistManager.Models
                 ItemButton.WhenClicked.AddListener(new Action(() => Toggle()));
 
                 ItemButton.gameObject.SetActive(true);
+
+                ItemButton.ForceButtonActiveEnabled(true);
+                ItemButton.UpdateVisualState();
             }
             catch (Exception ex)
             {
@@ -431,6 +435,36 @@ namespace SRPlaylistManager.Models
 
             // Not found
             return -1;
+        }
+
+        /// <summary>
+        /// Checks if the given hash matches with the song, fallback to name+author match.
+        /// </summary>
+        /// <param name="hash"></param>
+        /// <param name="name"></param>
+        /// <param name="author"></param>
+        /// <param name="playlistSong"></param>
+        /// <returns></returns>
+        public static bool SongMatches(string hash, string name, string author, PlaylistSong playlistSong)
+        {
+            if (playlistSong == null)
+                return false;
+
+            // Based on hash primarily
+            if (!string.IsNullOrEmpty(playlistSong.hash))
+            {
+                if (playlistSong.hash.Equals(hash))
+                {
+                    return true;
+                }
+            }
+            // Fall back on name and author match
+            else if (playlistSong.name.ToLower().Equals(name.ToLower()) && playlistSong.author.ToLower().Equals(author.ToLower()))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private bool SongsMatchNameAuthor(PlaylistSong a, PlaylistSong b)

--- a/SRPlaylistManager/MonoBehavior/AbstractPlaylistMenuMonoBehavior.cs
+++ b/SRPlaylistManager/MonoBehavior/AbstractPlaylistMenuMonoBehavior.cs
@@ -59,6 +59,7 @@ namespace SRPlaylistManager.MonoBehavior
             return panel;
         }
 
+        protected virtual Vector3 GetPanelScale() => Vector3.one * 0.2f;
         protected virtual Vector3 GetPanelOffset() => Vector3.zero;
 
         public void OpenMenu()
@@ -94,6 +95,9 @@ namespace SRPlaylistManager.MonoBehavior
             if (playlistPanel == null)
             {
                 playlistPanel = CreatePlaylistPanel(viewToHide);
+
+                // Scale as needed
+                playlistPanel.Panel.transform.localScale = GetPanelScale();
 
                 // Offset panel as needed
                 playlistPanel.Panel.transform.localPosition += GetPanelOffset();

--- a/SRPlaylistManager/MonoBehavior/MultiplayerPlaylistMenuMonoBehavior.cs
+++ b/SRPlaylistManager/MonoBehavior/MultiplayerPlaylistMenuMonoBehavior.cs
@@ -14,13 +14,18 @@ namespace SRPlaylistManager.MonoBehavior
     {
         public MultiplayerPlaylistMenuMonoBehavior(IntPtr ptr) : base(ptr) { }
 
-        private Vector3 _panelOffset = new Vector3(0f, 0f, 2f);
+        private Vector3 _panelOffset = new Vector3(0f, 0f, 5f);
         protected override Vector3 GetPanelOffset() => _panelOffset;
+
+        private Vector3 _panelScale = Vector3.one * 0.5f;
+        protected override Vector3 GetPanelScale() => _panelScale;
+
+        public GameObject GetMultiplayerRoomPanel() => GameObject.Find("Main Stage Prefab/Z-Wrap/Multiplayer/RoomPanel/Scale Wrap/MultiplayerRoomPanel");
 
         protected override GameObject GetToggledView()
         {
             // Find good parent so the panel can be seen
-            var center = GameObject.Find("Main Stage Prefab/Z-Wrap/Multiplayer/RoomPanel/Scale Wrap/MultiplayerRoomPanel");
+            var center = GetMultiplayerRoomPanel();
             _logger.Msg("Toggled: " + center);
             return center;
         }

--- a/SRPlaylistManager/SRPlaylistManager.cs
+++ b/SRPlaylistManager/SRPlaylistManager.cs
@@ -3,8 +3,10 @@ using Il2CppSynth.SongSelection;
 using Il2CppUtil.Controller;
 using MelonLoader;
 using SRModCore;
+using SRPlaylistManager.Models;
 using SRPlaylistManager.MonoBehavior;
 using SRPlaylistManager.Services;
+using System.Collections;
 using UnityEngine;
 
 namespace SRPlaylistManager
@@ -12,7 +14,7 @@ namespace SRPlaylistManager
     public class SRPlaylistManager : MelonMod
     {
         // If set, adds a ton more logs to debug issues
-        public static bool VERBOSE_LOGS = false;
+        public static bool VERBOSE_LOGS = true;
 
         public static SRPlaylistManager Instance { get; private set; }
 
@@ -116,6 +118,83 @@ namespace SRPlaylistManager
             }
 
             multiplayerMonoBehavior?.OpenMenu();
+        }
+
+        /// <summary>
+        /// Checks if the currently selected song is in favorites and/or any other playlist.
+        /// Returns false for both if the current song can't be determined (or there is none selected)
+        /// </summary>
+        /// <param name="isInFavorites"></param>
+        /// <param name="isInPlaylist"></param>
+        public void GetCurrentSongPlaylistState(out bool isInFavorites,  out bool isInPlaylist)
+        {
+            isInFavorites = false;
+            isInPlaylist = false;
+
+            if (SongSelectionManager.GetInstance == null)
+                return;
+
+            var selectedTrack = SongSelectionManager.GetInstance.SelectedGameTrack;
+            if (selectedTrack == null)
+                return;
+
+            // Easy enough :)
+            // Note - playlist.Songs is null for the Favorites playlist, so this being here helps simplify logic a bit
+            isInFavorites = selectedTrack.OnFavorites;
+
+            var playlists = playlistService.GetPlaylists();
+            foreach (var playlist in playlists)
+            {
+                if (playlist == null || playlist.Songs == null)
+                    continue;
+
+                foreach (var song in playlist.Songs)
+                {
+                    if (song == null)
+                        continue;
+
+                    if (PlaylistPanelItem.SongMatches(selectedTrack.LeaderboardHash, selectedTrack.TrackName, selectedTrack.Author, song))
+                    {
+                        // If found in any playlist, we have all the info we need and can exit early
+                        isInPlaylist = true;
+                        return;
+                    }
+                }
+            }
+        }
+
+        public void OnMultiplayerTrackFill()
+        {
+            MelonCoroutines.Start(RefreshMultiplayerDelayed());
+        }
+
+        private IEnumerator RefreshMultiplayerDelayed()
+        {
+            LogVerbose("Waiting for MP track");
+            
+            // Wait for track to be set
+            while (SongSelectionManager.GetInstance == null || SongSelectionManager.GetInstance.SelectedGameTrack == null)
+            {
+                yield return null;
+            }
+
+            PlaylistManagementController.GetInstance?.TryDisplayCorrectRemoveFavoriteButton();
+
+            LogVerbose("Waiting for MP favorite button");
+            while (SongSelectionManager.GetInstance == null || SongSelectionManager.GetInstance.favoriteBtn == null || SongSelectionManager.GetInstance.favoriteBtn.synthUIButton == null)
+            {
+                // I'm not sure why, but when returning from a multiplayer run the synthUIButton gets nulled out...but it's on the same GO so I just set it again here so things don't break and properly refresh.
+                if (SongSelectionManager.GetInstance?.favoriteBtn != null && SongSelectionManager.GetInstance.favoriteBtn.synthUIButton == null)
+                {
+                    SongSelectionManager.GetInstance.favoriteBtn.synthUIButton = SongSelectionManager.GetInstance.favoriteBtn.GetComponent<SynthUIButton>();
+                }
+
+                yield return null;
+            }
+
+            LogVerbose("Done waiting; refreshing MP");
+
+            SongSelectionManager.GetInstance?.UpdateFavoriteButtonState();
         }
 
         public void Log(string message)

--- a/SRPlaylistManager/SRPlaylistManager.cs
+++ b/SRPlaylistManager/SRPlaylistManager.cs
@@ -1,4 +1,6 @@
 ﻿using Il2Cpp;
+using Il2Cppcom.Kluge.XR.Utils;
+using Il2CppSynth.Multiplayer;
 using Il2CppSynth.SongSelection;
 using Il2CppUtil.Controller;
 using MelonLoader;
@@ -8,6 +10,7 @@ using SRPlaylistManager.MonoBehavior;
 using SRPlaylistManager.Services;
 using System.Collections;
 using UnityEngine;
+using static MelonLoader.MelonLogger;
 
 namespace SRPlaylistManager
 {
@@ -65,6 +68,9 @@ namespace SRPlaylistManager
             else
             {
                 LogVerbose("Playlist multiplayer GO found");
+
+                // Refresh UI, mostly to make sure the favorites/playlist button is active
+                OnMultiplayerTrackFill();
             }
         }
 
@@ -168,10 +174,18 @@ namespace SRPlaylistManager
             MelonCoroutines.Start(RefreshMultiplayerDelayed());
         }
 
+        public void OnOpenMultiplayerRoomMenu(Il2CppSynth.Versus.Room room)
+        {
+            var zWrap = GameObject.Find("Main Stage Prefab/Z-Wrap");
+            EnsureMultiplayerSetup(zWrap);
+
+            // Refresh MP state when returning to menu, since this is also needed when returning from a song
+            // if we are the client after the host returns (since we miss the host's song update then)
+            OnMultiplayerTrackFill();
+        }
+
         private IEnumerator RefreshMultiplayerDelayed()
         {
-            LogVerbose("Waiting for MP track");
-            
             // Wait for track to be set
             while (SongSelectionManager.GetInstance == null || SongSelectionManager.GetInstance.SelectedGameTrack == null)
             {
@@ -180,7 +194,6 @@ namespace SRPlaylistManager
 
             PlaylistManagementController.GetInstance?.TryDisplayCorrectRemoveFavoriteButton();
 
-            LogVerbose("Waiting for MP favorite button");
             while (SongSelectionManager.GetInstance == null || SongSelectionManager.GetInstance.favoriteBtn == null || SongSelectionManager.GetInstance.favoriteBtn.synthUIButton == null)
             {
                 // I'm not sure why, but when returning from a multiplayer run the synthUIButton gets nulled out...but it's on the same GO so I just set it again here so things don't break and properly refresh.
@@ -192,9 +205,16 @@ namespace SRPlaylistManager
                 yield return null;
             }
 
-            LogVerbose("Done waiting; refreshing MP");
-
             SongSelectionManager.GetInstance?.UpdateFavoriteButtonState();
+
+            // Make sure the favorite button is enabled!
+            // When returning from a multiplayer run _after_ the host, this is turned off :/
+            // Fix it here. In the future this may be unnecessary
+            var mpPanel = multiplayerMonoBehavior.GetMultiplayerRoomPanel();
+            var bottomPanel = mpPanel.transform.Find("MainPanel/BottomPanel");
+            var favWrap = bottomPanel.transform.Find("Song Info Wrap/Favorite Wrap");
+            logger.Msg("Ensuring favorite button is shown!");
+            favWrap.SetActive(true);
         }
 
         public void Log(string message)

--- a/SRPlaylistManager/SRPlaylistManager.csproj
+++ b/SRPlaylistManager/SRPlaylistManager.csproj
@@ -55,6 +55,9 @@
     <Reference Include="UnityEngine.UI">
       <HintPath>$(SynthRidersDir)\MelonLoader\Il2CppAssemblies\UnityEngine.UI.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.UIModule">
+      <HintPath>$(SynthRidersDir)\MelonLoader\Il2CppAssemblies\UnityEngine.UIModule.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SRModCore\SRModCore\SRModCore.csproj" />

--- a/SRPlaylistManager/Services/PlaylistService.cs
+++ b/SRPlaylistManager/Services/PlaylistService.cs
@@ -22,6 +22,12 @@ namespace SRPlaylistManager.Services
         {
             var playlists = new List<PlaylistItem>();
 
+            if (PlaylistManagementController.GetInstance?.UserPlaylistList?.playlists == null)
+            {
+                logger.Error("Can't retrieve playlists (null)!");
+                return playlists;
+            }
+
             var playlistItems = PlaylistManagementController.GetInstance.UserPlaylistList.playlists;
             foreach (var playlistItem in playlistItems)
             {


### PR DESCRIPTION
Playlists should now be editable in all multiplayer situations. Needed to fix a bug for the favorites wrap being hidden on return from run through for non-hosts. Also, scale was wonky so that's fixed now.